### PR TITLE
Remove webkit text fill color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -759,7 +759,6 @@ html {
         /* Additional Safari gradient text fallback */
         background: -webkit-linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
     }
 }
 


### PR DESCRIPTION
Remove `-webkit-text-fill-color` from Safari-specific styles to allow text to fall back to the standard `color` property.

---
<a href="https://cursor.com/background-agent?bcId=bc-e166450e-7227-49d9-ad71-47afe8fca3a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e166450e-7227-49d9-ad71-47afe8fca3a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

